### PR TITLE
 Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/src/main/java/org/dataalgorithms/bonus/friendrecommendation/mapreduce/PairOfLongs.java
+++ b/src/main/java/org/dataalgorithms/bonus/friendrecommendation/mapreduce/PairOfLongs.java
@@ -180,10 +180,10 @@ public class PairOfLongs implements WritableComparable<PairOfLongs> {
          if (thisLeftValue == thatLeftValue) {
            long thisRightValue = readLong(b1, s1 + 8);
            long thatRightValue = readLong(b2, s2 + 8);
-           return (thisRightValue < thatRightValue ? -1 : (thisRightValue == thatRightValue ? 0 : 1));
+           return thisRightValue < thatRightValue ? -1 : (thisRightValue == thatRightValue ? 0 : 1);
          }
 
-         return (thisLeftValue < thatLeftValue ? -1 : (thisLeftValue == thatLeftValue ? 0 : 1));
+         return thisLeftValue < thatLeftValue ? -1 : (thisLeftValue == thatLeftValue ? 0 : 1);
       }
    }
 

--- a/src/main/java/org/dataalgorithms/bonus/logquery/spark/SparkLogQuery.java
+++ b/src/main/java/org/dataalgorithms/bonus/logquery/spark/SparkLogQuery.java
@@ -98,7 +98,7 @@ public class SparkLogQuery {
                                      >() {
         public Boolean call(Tuple2<Tuple3<String, String, String>, LogStatistics> s) { 
             Tuple3<String, String, String> t3 = s._1;
-            return (t3._1() != null); // exclude Tuple3(null,null,null)
+            return t3._1() != null; // exclude Tuple3(null,null,null)
         }
     });
 

--- a/src/main/java/org/dataalgorithms/bonus/outlierdetection/spark/OutlierDetection.java
+++ b/src/main/java/org/dataalgorithms/bonus/outlierdetection/spark/OutlierDetection.java
@@ -55,7 +55,7 @@ public class OutlierDetection {
        @Override
        public int compare(Tuple2<String,Double> t1, 
                           Tuple2<String,Double> t2) {
-          return (t1._2.compareTo(t2._2)); // sort based on AVF Score
+          return t1._2.compareTo(t2._2); // sort based on AVF Score
        }
     }
     

--- a/src/main/java/org/dataalgorithms/chap09/spark/SparkFriendRecommendation.java
+++ b/src/main/java/org/dataalgorithms/chap09/spark/SparkFriendRecommendation.java
@@ -117,7 +117,7 @@ public class SparkFriendRecommendation {
         for (Tuple2<Long, Long> t2 : values) {
             final Long toUser = t2._1;
             final Long mutualFriend = t2._2;
-            final boolean alreadyFriend = (mutualFriend == -1);
+            final boolean alreadyFriend = mutualFriend == -1;
 
             if (mutualFriends.containsKey(toUser)) {
                 if (alreadyFriend) {

--- a/src/main/java/org/dataalgorithms/chap24/spark/SparkDNABaseCountFASTA.java
+++ b/src/main/java/org/dataalgorithms/chap24/spark/SparkDNABaseCountFASTA.java
@@ -81,7 +81,7 @@ public class SparkDNABaseCountFASTA  {
                 allBaseCounts.put(base, entry.getValue());
             }
             else {
-                allBaseCounts.put(base, (count + entry.getValue()));
+                allBaseCounts.put(base, count + entry.getValue());
             }
          }
       }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - “  Useless parentheses around expressions should be removed to prevent any misunderstanding ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.