### PR TITLE
"equals(Object obj)" should test argument type

### DIFF
--- a/src/main/java/org/dataalgorithms/bonus/friendrecommendation/mapreduce/PairOfLongs.java
+++ b/src/main/java/org/dataalgorithms/bonus/friendrecommendation/mapreduce/PairOfLongs.java
@@ -95,6 +95,10 @@ public class PairOfLongs implements WritableComparable<PairOfLongs> {
     *         otherwise
     */
    public boolean equals(Object obj) {
+     if (obj == null)
+        return false;
+     if (this.getClass() != obj.getClass())
+        return false;  
      PairOfLongs pair = (PairOfLongs) obj;
      return left == pair.getLeft() && right == pair.getRight();
    }

--- a/src/main/java/org/dataalgorithms/chap05/mapreduce/PairOfWords.java
+++ b/src/main/java/org/dataalgorithms/chap05/mapreduce/PairOfWords.java
@@ -146,6 +146,10 @@ public class PairOfWords implements WritableComparable<PairOfWords> {
 	 * @return <code>true</code> if <code>obj</code> is equal to this object, <code>false</code> otherwise
 	 */
 	public boolean equals(Object obj) {
+		if (obj == null)
+			return false;
+		if (this.getClass() != obj.getClass())
+			return false;
 		PairOfWords pair = (PairOfWords) obj;
 		return leftElement.equals(pair.getLeftElement())
 				&& rightElement.equals(pair.getRightElement());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2097 - “  "equals(Object obj)" should test argument type ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2097
Please let me know if you have any questions.
Ayman Abdelghany.