### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/dataalgorithms/bonus/anagram/spark/SparkAnagram.java
+++ b/src/main/java/org/dataalgorithms/bonus/anagram/spark/SparkAnagram.java
@@ -22,7 +22,10 @@ import java.util.Arrays;
  */
 public class SparkAnagram {
 
-   public static void main(String[] args) throws Exception {
+    private SparkAnagram() {
+    }
+
+    public static void main(String[] args) throws Exception {
   
       // STEP-1: handle input parameters
       if (args.length != 3) {

--- a/src/main/java/org/dataalgorithms/bonus/cartesian/spark/TestCartesian.java
+++ b/src/main/java/org/dataalgorithms/bonus/cartesian/spark/TestCartesian.java
@@ -15,7 +15,10 @@ import java.util.ArrayList;
  */
 public class TestCartesian {
 
-   static JavaSparkContext createJavaSparkContext() throws Exception {
+    private TestCartesian() {
+    }
+
+    static JavaSparkContext createJavaSparkContext() throws Exception {
       SparkConf conf = new SparkConf();
       conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
       //JavaSparkContext ctx = new JavaSparkContext("yarn-cluster", "mytestprogram", conf); // yarn-specific

--- a/src/main/java/org/dataalgorithms/bonus/charcount/spark/basic/CharCount.java
+++ b/src/main/java/org/dataalgorithms/bonus/charcount/spark/basic/CharCount.java
@@ -20,7 +20,10 @@ import org.apache.spark.api.java.function.PairFlatMapFunction;
  *
  */
 public class CharCount {
-    
+
+    private CharCount() {
+    }
+
     static void printArguments(String[] args) {
         if ((args == null) || (args.length == 0)) {
             System.out.println("no arguments passed...");

--- a/src/main/java/org/dataalgorithms/bonus/charcount/spark/inmapper/CharCountInMapperCombiner.java
+++ b/src/main/java/org/dataalgorithms/bonus/charcount/spark/inmapper/CharCountInMapperCombiner.java
@@ -21,6 +21,9 @@ import org.apache.spark.api.java.function.FlatMapFunction;
  */
 public class CharCountInMapperCombiner {
 
+    private CharCountInMapperCombiner() {
+    }
+
     public static void main(String[] args) throws Exception {
         if (args.length != 2) {
            System.err.println("Usage: SparkCharCount <input> <output>");

--- a/src/main/java/org/dataalgorithms/bonus/charcount/spark/localaggregation/CharCountLocalAggregation.java
+++ b/src/main/java/org/dataalgorithms/bonus/charcount/spark/localaggregation/CharCountLocalAggregation.java
@@ -23,6 +23,9 @@ import org.apache.spark.api.java.function.PairFlatMapFunction;
  */
 public class CharCountLocalAggregation {
 
+    private CharCountLocalAggregation() {
+    }
+
     public static void main(String[] args) throws Exception {
        if (args.length != 2) {
           System.err.println("Usage: SparkCharCount <input> <output>");

--- a/src/main/java/org/dataalgorithms/bonus/friendrecommendation/spark/SparkFriendRecommendation.java
+++ b/src/main/java/org/dataalgorithms/bonus/friendrecommendation/spark/SparkFriendRecommendation.java
@@ -36,7 +36,10 @@ import org.apache.commons.lang.StringUtils;
  */
 public class SparkFriendRecommendation {
 
-   /**
+    private SparkFriendRecommendation() {
+    }
+
+    /**
     * Build a pair of Longs(x,y) where x <= y
     */
    private static Tuple2<Long,Long> buildSortedPairOfLongs(long a, long b) {

--- a/src/main/java/org/dataalgorithms/bonus/friendrecommendation/spark/SubmitSparkJobToYARNFromJavaCode.java
+++ b/src/main/java/org/dataalgorithms/bonus/friendrecommendation/spark/SubmitSparkJobToYARNFromJavaCode.java
@@ -12,6 +12,9 @@ import org.apache.spark.SparkConf;
  */
 public class SubmitSparkJobToYARNFromJavaCode {
 
+   private SubmitSparkJobToYARNFromJavaCode() {
+   }
+
    public static void main(String[] arguments) throws Exception {
 
        // prepare arguments to be passed to 

--- a/src/main/java/org/dataalgorithms/bonus/logquery/spark/SparkLogQuery.java
+++ b/src/main/java/org/dataalgorithms/bonus/logquery/spark/SparkLogQuery.java
@@ -36,7 +36,10 @@ public class SparkLogQuery {
     "10.20.30.42,u400,700,query2"
     );
 
-  // tokens = [<ip-address><user-id><number-of-bytes><query>]
+    private SparkLogQuery() {
+    }
+
+    // tokens = [<ip-address><user-id><number-of-bytes><query>]
   public static Tuple3<String, String, String> createKey(String[] tokens) {
      String userID = tokens[1];
      if (userID.equals("-")) {

--- a/src/main/java/org/dataalgorithms/bonus/outlierdetection/spark/OutlierDetection.java
+++ b/src/main/java/org/dataalgorithms/bonus/outlierdetection/spark/OutlierDetection.java
@@ -46,8 +46,11 @@ import org.apache.commons.lang.StringUtils;
 public class OutlierDetection {
 
     private static final Logger THE_LOGGER = Logger.getLogger(OutlierDetection.class);
-      
-    
+
+    private OutlierDetection() {
+    }
+
+
     static class TupleComparatorAscending 
        implements Comparator<Tuple2<String,Double>>, Serializable {
        final static TupleComparatorAscending INSTANCE = new TupleComparatorAscending();

--- a/src/main/java/org/dataalgorithms/bonus/perkeyaverage/spark/PerKeyAverage.java
+++ b/src/main/java/org/dataalgorithms/bonus/perkeyaverage/spark/PerKeyAverage.java
@@ -21,7 +21,10 @@ import org.apache.spark.api.java.function.PairFunction;
  */
 
 public final class PerKeyAverage {
-    
+
+    private PerKeyAverage() {
+    }
+
     static final List<Tuple2<String, Double>> getSampleInput() {
         List<Tuple2<String, Double>> input = new ArrayList<Tuple2<String, Double>>();
         // key: "zebra"

--- a/src/main/java/org/dataalgorithms/bonus/rankproduct/spark/SparkRankProductUsingCombineByKey.java
+++ b/src/main/java/org/dataalgorithms/bonus/rankproduct/spark/SparkRankProductUsingCombineByKey.java
@@ -38,6 +38,9 @@ public class SparkRankProductUsingCombineByKey {
 
     private static final Logger THE_LOGGER = Logger.getLogger(SparkRankProductUsingCombineByKey.class);
 
+    private SparkRankProductUsingCombineByKey() {
+    }
+
     /**
      * AverageCount is used by combineByKey() to hold 
      * the total values and their count.

--- a/src/main/java/org/dataalgorithms/bonus/rankproduct/spark/SparkRankProductUsingGroupByKey.java
+++ b/src/main/java/org/dataalgorithms/bonus/rankproduct/spark/SparkRankProductUsingGroupByKey.java
@@ -33,7 +33,10 @@ import org.apache.commons.lang.StringUtils;
 public class SparkRankProductUsingGroupByKey {
 
     private static final Logger THE_LOGGER = Logger.getLogger(SparkRankProductUsingGroupByKey.class);
-        
+
+    private SparkRankProductUsingGroupByKey() {
+    }
+
     static void debug(String[] args)  {
         for (int i=0; i < args.length; i++){
             THE_LOGGER.info("***debug*** args["+i+"]="+args[i]);

--- a/src/main/java/org/dataalgorithms/bonus/rankproduct/spark/Util.java
+++ b/src/main/java/org/dataalgorithms/bonus/rankproduct/spark/Util.java
@@ -14,7 +14,10 @@ import org.apache.spark.api.java.JavaSparkContext;
 public class Util {
 
     private static final Logger THE_LOGGER = Logger.getLogger(Util.class);
-    
+
+    private Util() {
+    }
+
     static JavaSparkContext createJavaSparkContext(boolean useYARN) {
         JavaSparkContext context;
         if (useYARN) {

--- a/src/main/java/org/dataalgorithms/bonus/sortedwordcount/spark/SparkSortedWordCount.java
+++ b/src/main/java/org/dataalgorithms/bonus/sortedwordcount/spark/SparkSortedWordCount.java
@@ -24,6 +24,9 @@ import org.apache.spark.api.java.function.PairFunction;
  */
 public class SparkSortedWordCount {
 
+    private SparkSortedWordCount() {
+    }
+
     public static void main(String[] args) throws Exception {
        if (args.length != 4) {
           System.err.println("Usage: SparkSortedWordCount <N> <input> <output> <orderBy>");

--- a/src/main/java/org/dataalgorithms/bonus/wordcount/spark/SparkWordCount.java
+++ b/src/main/java/org/dataalgorithms/bonus/wordcount/spark/SparkWordCount.java
@@ -22,7 +22,10 @@ import java.util.Collections;
  */
 public class SparkWordCount {
 
-    public static void main(String[] args) throws Exception {
+   private SparkWordCount() {
+   }
+
+   public static void main(String[] args) throws Exception {
        if (args.length != 3) {
           System.err.println("Usage: SparkWordCount <N> <input> <output>");
           System.exit(1);

--- a/src/main/java/org/dataalgorithms/chap01/spark/SparkSecondarySort.java
+++ b/src/main/java/org/dataalgorithms/chap01/spark/SparkSecondarySort.java
@@ -50,7 +50,10 @@ import java.util.Collections;
  *
  */
 public class SparkSecondarySort {
-  public static void main(String[] args) throws Exception {
+    private SparkSecondarySort() {
+    }
+
+    public static void main(String[] args) throws Exception {
   
     // STEP-1: read input parameters and validate them
     if (args.length < 1) {

--- a/src/main/java/org/dataalgorithms/chap02/mapreduce/SecondarySortDriver.java
+++ b/src/main/java/org/dataalgorithms/chap02/mapreduce/SecondarySortDriver.java
@@ -20,6 +20,9 @@ import org.dataalgorithms.util.HadoopUtil;
  */
 public class SecondarySortDriver {
 
+	private SecondarySortDriver() {
+	}
+
 	public static void main(String[] args) throws Exception {
 
 	    Configuration conf = new Configuration();

--- a/src/main/java/org/dataalgorithms/chap03/mapreduce/SequenceFileWriterForTopN.java
+++ b/src/main/java/org/dataalgorithms/chap03/mapreduce/SequenceFileWriterForTopN.java
@@ -22,6 +22,9 @@ import java.util.Random;
  */
 public class SequenceFileWriterForTopN {
 
+    private SequenceFileWriterForTopN() {
+    }
+
     public static void main(String[] args) throws IOException {
         if (args.length != 2) {
             throw new IOException("usage: java org.dataalgorithms.chap03.mapreduce.SequenceFileWriterForTopN <hdfs-path> <number-of-entries>");

--- a/src/main/java/org/dataalgorithms/chap03/spark/Top10.java
+++ b/src/main/java/org/dataalgorithms/chap03/spark/Top10.java
@@ -46,7 +46,10 @@ import java.util.Collections;
  */
 public class Top10 {
 
-   public static void main(String[] args) throws Exception {
+    private Top10() {
+    }
+
+    public static void main(String[] args) throws Exception {
   
       // STEP-1: handle input parameters
       if (args.length < 1) {

--- a/src/main/java/org/dataalgorithms/chap03/spark/Top10NonUnique.java
+++ b/src/main/java/org/dataalgorithms/chap03/spark/Top10NonUnique.java
@@ -52,7 +52,10 @@ import java.util.Collections;
  */
 public class Top10NonUnique {
 
-   public static void main(String[] args) throws Exception {
+    private Top10NonUnique() {
+    }
+
+    public static void main(String[] args) throws Exception {
       // STEP-1: handle input parameters
       if (args.length < 2) {
          System.err.println("Usage: Top10 <input-path> <topN>");

--- a/src/main/java/org/dataalgorithms/chap04/mapreduce/LeftJoinDriver.java
+++ b/src/main/java/org/dataalgorithms/chap04/mapreduce/LeftJoinDriver.java
@@ -22,8 +22,11 @@ import java.io.IOException;
  *
  */
 public class LeftJoinDriver {
-  
-  public static void main( String[] args ) throws Exception {
+
+  private LeftJoinDriver() {
+  }
+
+  public static void main(String[] args ) throws Exception {
       Path transactions = new Path(args[0]);  // input
       Path users = new Path(args[1]);         // input
       Path output = new Path(args[2]);        // output

--- a/src/main/java/org/dataalgorithms/chap04/mapreduce/LocationCountDriver.java
+++ b/src/main/java/org/dataalgorithms/chap04/mapreduce/LocationCountDriver.java
@@ -21,7 +21,10 @@ import java.io.IOException;
  */
 public class LocationCountDriver {
 
-   public static void main( String[] args ) throws Exception {
+  private LocationCountDriver() {
+  }
+
+  public static void main(String[] args ) throws Exception {
       Path input = new Path(args[0]);
       Path output = new Path(args[1]);
       Configuration conf = new Configuration();

--- a/src/main/java/org/dataalgorithms/chap04/spark/SparkLeftOuterJoin.java
+++ b/src/main/java/org/dataalgorithms/chap04/spark/SparkLeftOuterJoin.java
@@ -32,7 +32,10 @@ import java.util.Collections;
  */ 
 public class SparkLeftOuterJoin {
 
-  public static void main(String[] args) throws Exception {
+    private SparkLeftOuterJoin() {
+    }
+
+    public static void main(String[] args) throws Exception {
     if (args.length < 2) {
        System.err.println("Usage: SparkLeftOuterJoin <users> <transactions>");
        System.exit(1);

--- a/src/main/java/org/dataalgorithms/chap06/memorysort/SortInMemory_MovingAverageDriver.java
+++ b/src/main/java/org/dataalgorithms/chap06/memorysort/SortInMemory_MovingAverageDriver.java
@@ -22,8 +22,11 @@ import org.dataalgorithms.chap06.TimeSeriesData;
  *
  */
 public class SortInMemory_MovingAverageDriver {
- 
-    public static void main(String[] args) throws Exception {
+
+   private SortInMemory_MovingAverageDriver() {
+   }
+
+   public static void main(String[] args) throws Exception {
        Configuration conf = new Configuration();
        String[] otherArgs = new GenericOptionsParser(conf, args).getRemainingArgs();
        if (otherArgs.length != 3) {

--- a/src/main/java/org/dataalgorithms/chap06/pojo/TestSimpleMovingAverage.java
+++ b/src/main/java/org/dataalgorithms/chap06/pojo/TestSimpleMovingAverage.java
@@ -13,6 +13,9 @@ public class TestSimpleMovingAverage {
 
     private static final Logger THE_LOGGER = Logger.getLogger(TestSimpleMovingAverage.class);
 
+    private TestSimpleMovingAverage() {
+    }
+
     public static void main(String[] args) {
         // The invocation of the BasicConfigurator.configure method 
         // creates a rather simple log4j setup. This method is hardwired 

--- a/src/main/java/org/dataalgorithms/chap06/secondarysort/SortByMRF_MovingAverageDriver.java
+++ b/src/main/java/org/dataalgorithms/chap06/secondarysort/SortByMRF_MovingAverageDriver.java
@@ -23,8 +23,11 @@ import org.dataalgorithms.chap06.TimeSeriesData;
  *
  */  
 public class SortByMRF_MovingAverageDriver {
- 
-    public static void main(String[] args) throws Exception {
+
+   private SortByMRF_MovingAverageDriver() {
+   }
+
+   public static void main(String[] args) throws Exception {
         Configuration conf = new Configuration();
 		JobConf jobconf = new JobConf(conf, SortByMRF_MovingAverageDriver.class);
 		jobconf.setJobName("SortByMRF_MovingAverageDriver");

--- a/src/main/java/org/dataalgorithms/chap07/spark/FindAssociationRules.java
+++ b/src/main/java/org/dataalgorithms/chap07/spark/FindAssociationRules.java
@@ -24,8 +24,11 @@ import org.apache.spark.api.java.function.Function2;
  *
  */ 
 public class FindAssociationRules {
-  
-   static List<String> toList(String transaction) {
+
+    private FindAssociationRules() {
+    }
+
+    static List<String> toList(String transaction) {
       String[] items = transaction.trim().split(",");
       List<String> list = new ArrayList<String>();
       for (String item : items) {

--- a/src/main/java/org/dataalgorithms/chap08/spark/FindCommonFriends.java
+++ b/src/main/java/org/dataalgorithms/chap08/spark/FindCommonFriends.java
@@ -28,7 +28,10 @@ import java.util.HashMap;
  */
 public class FindCommonFriends {
 
-  public static void main(String[] args) throws Exception {
+    private FindCommonFriends() {
+    }
+
+    public static void main(String[] args) throws Exception {
   
     if (args.length < 1) {
        // Spark master URL:

--- a/src/main/java/org/dataalgorithms/chap09/spark/SparkFriendRecommendation.java
+++ b/src/main/java/org/dataalgorithms/chap09/spark/SparkFriendRecommendation.java
@@ -27,7 +27,10 @@ import java.util.HashMap;
  */
 public class SparkFriendRecommendation {
 
-  public static void main(String[] args) throws Exception {
+    private SparkFriendRecommendation() {
+    }
+
+    public static void main(String[] args) throws Exception {
     if (args.length < 1) {
        System.err.println("Usage: SparkFriendRecommendation <input-path>");
        System.exit(1);

--- a/src/main/java/org/dataalgorithms/chap10/spark/MovieRecommendations.java
+++ b/src/main/java/org/dataalgorithms/chap10/spark/MovieRecommendations.java
@@ -31,7 +31,10 @@ import java.util.Iterator;
  *
  */
 public class MovieRecommendations {
-  public static void main(String[] args) throws Exception {
+    private MovieRecommendations() {
+    }
+
+    public static void main(String[] args) throws Exception {
 
     //STEP-1: handle input parameters
     if (args.length < 1) {

--- a/src/main/java/org/dataalgorithms/chap10/spark/MovieRecommendationsWithJoin.java
+++ b/src/main/java/org/dataalgorithms/chap10/spark/MovieRecommendationsWithJoin.java
@@ -31,7 +31,10 @@ import java.util.Iterator;
  *
  */
 public class MovieRecommendationsWithJoin {
-  public static void main(String[] args) throws Exception {
+    private MovieRecommendationsWithJoin() {
+    }
+
+    public static void main(String[] args) throws Exception {
 
     //STEP-1: handle input parameters
     if (args.length < 1) {

--- a/src/main/java/org/dataalgorithms/chap11/projection/memorysort/SortInMemoryProjectionDriver.java
+++ b/src/main/java/org/dataalgorithms/chap11/projection/memorysort/SortInMemoryProjectionDriver.java
@@ -25,9 +25,12 @@ import org.dataalgorithms.util.HadoopUtil;
  */
 public class SortInMemoryProjectionDriver {
 	private static final Logger theLogger = 
-	   Logger.getLogger(SortInMemoryProjectionDriver.class); 
-	   
-    public static void main(String[] args) throws Exception {
+	   Logger.getLogger(SortInMemoryProjectionDriver.class);
+
+   private SortInMemoryProjectionDriver() {
+   }
+
+   public static void main(String[] args) throws Exception {
 		long startTime = System.currentTimeMillis();	
     
        Configuration conf = new Configuration();

--- a/src/main/java/org/dataalgorithms/chap11/projection/secondarysort/SecondarySortProjectionDriver.java
+++ b/src/main/java/org/dataalgorithms/chap11/projection/secondarysort/SecondarySortProjectionDriver.java
@@ -27,8 +27,11 @@ import org.dataalgorithms.util.HadoopUtil;
 public class SecondarySortProjectionDriver {
 
 	private static final Logger theLogger = 
-	   Logger.getLogger(SecondarySortProjectionDriver.class); 
- 
+	   Logger.getLogger(SecondarySortProjectionDriver.class);
+
+    private SecondarySortProjectionDriver() {
+    }
+
     public static void main(String[] args) throws Exception {
 		long startTime = System.currentTimeMillis();	
         Configuration conf = new Configuration();

--- a/src/main/java/org/dataalgorithms/chap13/spark/kNN.java
+++ b/src/main/java/org/dataalgorithms/chap13/spark/kNN.java
@@ -26,8 +26,11 @@ import com.google.common.base.Splitter;
  *
  */
 public class kNN {
-   
-   /**
+
+    private kNN() {
+    }
+
+    /**
     * @param str a comma (or semicolon) separated list of double values
     * str is like "1.1,2.2,3.3" or "1.1;2.2;3.3"
     *

--- a/src/main/java/org/dataalgorithms/chap16/spark/CountTriangles.java
+++ b/src/main/java/org/dataalgorithms/chap16/spark/CountTriangles.java
@@ -22,7 +22,10 @@ import java.util.Collections;
  *
  */
 public class CountTriangles {
-  public static void main(String[] args) throws Exception {
+    private CountTriangles() {
+    }
+
+    public static void main(String[] args) throws Exception {
     if (args.length < 1) {
        System.err.println("Usage: CountTriangles <input-path>");
        System.exit(1);

--- a/src/main/java/org/dataalgorithms/chap17/mapreduce/KmerUtil.java
+++ b/src/main/java/org/dataalgorithms/chap17/mapreduce/KmerUtil.java
@@ -7,7 +7,10 @@ package org.dataalgorithms.chap17.mapreduce;
  *
  */
 public class KmerUtil   {
-	
+
+	private KmerUtil() {
+	}
+
 	public static String getKmer(String str, int start, int k) {
     	if (start+k > str.length()) {
     		return null;

--- a/src/main/java/org/dataalgorithms/chap17/spark/Kmer.java
+++ b/src/main/java/org/dataalgorithms/chap17/spark/Kmer.java
@@ -27,8 +27,11 @@ import org.apache.spark.broadcast.Broadcast;
  *
  */
 public class Kmer {
-  
-   public static void main(String[] args) throws Exception {
+
+    private Kmer() {
+    }
+
+    public static void main(String[] args) throws Exception {
       // STEP-1: handle input parameters
       if (args.length < 3) {
          System.err.println("Usage: Kmer <fastq-file> <K> <N>");

--- a/src/main/java/org/dataalgorithms/chap22/spark/SparkTtest.java
+++ b/src/main/java/org/dataalgorithms/chap22/spark/SparkTtest.java
@@ -30,6 +30,9 @@ import java.io.BufferedReader;
  */
 public class SparkTtest {
 
+   private SparkTtest() {
+   }
+
    static Map<String, Double> createTimeTable(String filename) throws Exception {
       Map<String, Double> map = new HashMap<String, Double>();
       BufferedReader in = null;

--- a/src/main/java/org/dataalgorithms/chap23/spark/Pearson.java
+++ b/src/main/java/org/dataalgorithms/chap23/spark/Pearson.java
@@ -16,7 +16,10 @@ import org.apache.commons.math3.stat.correlation.PearsonsCorrelation;
 public class Pearson {
 
    final static PearsonsCorrelation PC = new PearsonsCorrelation();
-  
+
+   private Pearson() {
+   }
+
    public static double getCorrelation(List<Double> X, List<Double> Y) {
       double[] xArray = toDoubleArray(X);
       double[] yArray = toDoubleArray(Y);

--- a/src/main/java/org/dataalgorithms/chap23/spark/TestPearson.java
+++ b/src/main/java/org/dataalgorithms/chap23/spark/TestPearson.java
@@ -12,8 +12,11 @@ import java.util.Arrays;
  *
  */
 public class TestPearson {
-  
-   public static void main(String[] args) {
+
+    private TestPearson() {
+    }
+
+    public static void main(String[] args) {
       test0(args);
       test1(args);
       test2(args);

--- a/src/main/java/org/dataalgorithms/chap23/spark/TestSpearman.java
+++ b/src/main/java/org/dataalgorithms/chap23/spark/TestSpearman.java
@@ -10,7 +10,10 @@ import java.util.List;
  *
  */
 public class TestSpearman {
-		
+
+	private TestSpearman() {
+	}
+
 	public static void main(String[] args) {
 	    test0(args);
 	    test1(args);

--- a/src/main/java/org/dataalgorithms/chap24/spark/SparkDNABaseCountFASTA.java
+++ b/src/main/java/org/dataalgorithms/chap24/spark/SparkDNABaseCountFASTA.java
@@ -22,7 +22,10 @@ import org.apache.spark.api.java.function.FlatMapFunction;
  */
 public class SparkDNABaseCountFASTA  {
 
-   public static void main(String[] args) throws Exception {
+    private SparkDNABaseCountFASTA() {
+    }
+
+    public static void main(String[] args) throws Exception {
       // STEP-1: handle input parameters
       if (args.length != 1) {
          System.err.println("Usage: SparkDNABaseCountFASTA <input-path>");

--- a/src/main/java/org/dataalgorithms/chap24/spark/SparkDNABaseCountFASTQ.java
+++ b/src/main/java/org/dataalgorithms/chap24/spark/SparkDNABaseCountFASTQ.java
@@ -32,7 +32,10 @@ import org.dataalgorithms.chap24.mapreduce.FastqInputFormat;
  */
 public class SparkDNABaseCountFASTQ {
 
-   public static void main(String[] args) throws Exception {
+    private SparkDNABaseCountFASTQ() {
+    }
+
+    public static void main(String[] args) throws Exception {
       // STEP-1: handle input parameters
       if (args.length != 1) {
          System.err.println("Usage: SparkDNABaseCountFASTQ <input-path>");

--- a/src/main/java/org/dataalgorithms/chap26/spark/SparkGeneAggregationByAverage.java
+++ b/src/main/java/org/dataalgorithms/chap26/spark/SparkGeneAggregationByAverage.java
@@ -28,8 +28,11 @@ import java.util.ArrayList;
 public class SparkGeneAggregationByAverage {
 
    static final Tuple2<String, String> Tuple2Null = new Tuple2<String, String>("n", "n");
-   
-   /**
+
+    private SparkGeneAggregationByAverage() {
+    }
+
+    /**
     * Convert all bioset files into a List<biosetFileName>
     *
     * @param biosets is a filename, which holds all bioset files as HDFS entries

--- a/src/main/java/org/dataalgorithms/chap28/mapreduce/MeanDriver.java
+++ b/src/main/java/org/dataalgorithms/chap28/mapreduce/MeanDriver.java
@@ -28,8 +28,11 @@ import org.dataalgorithms.util.HadoopUtil;
  *
  */
 public class MeanDriver {
- 
-    public static void main(String[] args) throws Exception {
+
+   private MeanDriver() {
+   }
+
+   public static void main(String[] args) throws Exception {
        Configuration conf = new Configuration();
        String[] otherArgs = new GenericOptionsParser(conf, args).getRemainingArgs();
        if (otherArgs.length != 2) {

--- a/src/main/java/org/dataalgorithms/chap28/spark/SparkMeanMonodized.java
+++ b/src/main/java/org/dataalgorithms/chap28/spark/SparkMeanMonodized.java
@@ -38,7 +38,10 @@ import org.apache.spark.api.java.function.PairFunction;
  */
 public class SparkMeanMonodized  {
 
-   public static void main(String[] args) throws Exception {
+    private SparkMeanMonodized() {
+    }
+
+    public static void main(String[] args) throws Exception {
       // STEP-1: handle input parameters
       if (args.length != 1) {
          System.err.println("Usage: SparkMeanMonodized <input-path>");

--- a/src/main/java/org/dataalgorithms/chap29/combinesmallfilesbybuckets/SmallFilesConsolidator.java
+++ b/src/main/java/org/dataalgorithms/chap29/combinesmallfilesbybuckets/SmallFilesConsolidator.java
@@ -25,6 +25,9 @@ public class SmallFilesConsolidator {
     // this directory is configurable
     private static String MERGED_HDFS_ROOT_DIR = "/tmp/";
 
+    private SmallFilesConsolidator() {
+    }
+
     public static int getNumberOfBuckets(int totalFiles, 
                                          int numberOfMapSlotsAvailable,
                                          int maxFilesPerBucket) {

--- a/src/main/java/org/dataalgorithms/client/SubmitSparkJobToClusterFromJavaCode.java
+++ b/src/main/java/org/dataalgorithms/client/SubmitSparkJobToClusterFromJavaCode.java
@@ -20,6 +20,9 @@ public class SubmitSparkJobToClusterFromJavaCode {
     
     static final Logger THE_LOGGER = Logger.getLogger(SubmitSparkJobToClusterFromJavaCode.class);
 
+    private SubmitSparkJobToClusterFromJavaCode() {
+    }
+
     public static void main(String[] arguments) throws Exception {
         long startTime = System.currentTimeMillis();    
         test(arguments); // ... the code being measured ...    

--- a/src/main/java/org/dataalgorithms/client/SubmitSparkJobToYARNFromJavaCode.java
+++ b/src/main/java/org/dataalgorithms/client/SubmitSparkJobToYARNFromJavaCode.java
@@ -66,7 +66,10 @@ public class SubmitSparkJobToYARNFromJavaCode {
         "log4j-1.2.17.jar",
         "spring-context-3.0.7.RELEASE.jar"
     );
-    
+
+    private SubmitSparkJobToYARNFromJavaCode() {
+    }
+
     private static String buildJars(String prefixJarDir) {
         StringBuilder builder = new StringBuilder();
         int counter = 0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “  Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.